### PR TITLE
Enable original endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**28/09/2023** [Version 3.6.3]
+ - Re-enable original endpoints (deprecated) to retain compatibility with Portal
+
 **21/09/2023** [Version 3.6.2]
  - Add a prefix (`/elcm/api/v1/`) to all endpoints
  - Allow defining and return a more complete description of the KPIs in the `/elcm/api/v1/<id>/kpis` endpoint

--- a/Scheduler/__init__.py
+++ b/Scheduler/__init__.py
@@ -37,6 +37,7 @@ Status.Initialize()
 HeartBeat.Initialize()
 
 from Scheduler.execution import bp as ExecutionBp
+app.register_blueprint(ExecutionBp, url_prefix='/execution', name='deprecatedExecutionApi')
 app.register_blueprint(ExecutionBp, url_prefix='/elcm/api/v1/execution')
 
 from Scheduler.dispatcher import bp as DispatcherBp
@@ -44,10 +45,12 @@ app.register_blueprint(DispatcherBp, url_prefix='/api/v0', name='deprecatedDispa
 app.register_blueprint(DispatcherBp, url_prefix='/elcm/api/v1/experiment')
 
 from Scheduler.facility import bp as FacilityBp
+app.register_blueprint(FacilityBp, url_prefix='/facility', name='deprecatedFacilityApi')
 app.register_blueprint(FacilityBp, url_prefix='/elcm/api/v1/facility')
 
 if config.EastWest.Enabled:
     from Scheduler.east_west import bp as EastwestBp
+    app.register_blueprint(EastwestBp, url_prefix='/distributed', name='deprecatedEastWestApi')
     app.register_blueprint(EastwestBp, url_prefix='/elcm/api/v1/distributed')
 
 Log.I(f'Optional East/West interface is {Log.State(config.EastWest.Enabled)}')


### PR DESCRIPTION
- Re-enable original endpoints (deprecated) to retain compatibility with Portal